### PR TITLE
- Import: add ability to show warning in dialog box (once a warning h…

### DIFF
--- a/reaper-adm-extension/src/reaper_adm/automationpoint.cpp
+++ b/reaper-adm-extension/src/reaper_adm/automationpoint.cpp
@@ -14,7 +14,7 @@ AutomationPoint::AutomationPoint(std::chrono::nanoseconds timeNs, std::chrono::n
     pointValue{val} {
 }
 
-AutomationPoint::AutomationPoint(double timeSeconds, double duration, double val) : pointTime{timeSeconds}, pointDuration{duration}, pointValue{val}
+AutomationPoint::AutomationPoint(double timeSeconds, double duration, ParameterValue val) : pointTime{timeSeconds}, pointDuration{duration}, pointValue{val}
 {
 }
 

--- a/reaper-adm-extension/src/reaper_adm/automationpoint.h
+++ b/reaper-adm-extension/src/reaper_adm/automationpoint.h
@@ -7,14 +7,15 @@ class ParameterValue {
 public:
   ParameterValue(double value) : value{value}, clipped{false} {}
   ParameterValue(double value, bool clipped) : value{value}, clipped{clipped} {}
+  ParameterValue(const ParameterValue& obj) : value{obj.value}, clipped{obj.clipped} {}
   double get() const { return value; }
   operator double() const { return get(); }
-  bool wasClipped() const { return clipped; }
-  void setClipped() { clipped = true; }
+ 
+  bool clipped;
 
 private:
   double value;
-  bool clipped;
+  
 };
 
 
@@ -23,7 +24,7 @@ class AutomationPoint
 public:
   explicit AutomationPoint(double val);
     AutomationPoint(std::chrono::nanoseconds timeNs, std::chrono::nanoseconds duration, double val);
-    AutomationPoint(double timeSeconds, double duration, double val);
+    AutomationPoint(double timeSeconds, double duration, ParameterValue val);
     double time() const;
     double duration() const;
     ParameterValue value() const;

--- a/reaper-adm-extension/src/reaper_adm/objectautomationelement.cpp
+++ b/reaper-adm-extension/src/reaper_adm/objectautomationelement.cpp
@@ -1,4 +1,4 @@
-﻿#include <optional>
+#include <optional>
 #include <tuple>
 #include "objectautomationelement.h"
 #include "automationenvelope.h"
@@ -177,7 +177,7 @@ namespace {
   ParameterStats getStatsFor(std::vector<AutomationPoint> const& points) {
     ParameterStats stats;
     for (auto const &point : points) {
-      if (point.value().wasClipped()) {
+      if (point.value().clipped) {
         ++stats.clipCount;
       }
     }

--- a/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.cpp
@@ -212,6 +212,8 @@ void admplug::EARPluginSuite::onProjectBuildComplete(const ReaperAPI & api)
         auto communicator = CommunicatorRegistry::getCommunicator<EarVstCommunicator>(samplesPort, commandPort);
         communicator->sendAdmAndTrackMappings(originalAdmDocument, trackMappingToAtu);
     }
+    
+    reportClippedParameters();
 }
 
 void EARPluginSuite::onCreateProject(const ProjectNode &, const ReaperAPI &api)
@@ -290,8 +292,8 @@ void EARPluginSuite::onObjectAutomation(const ObjectAutomation& automationElemen
 
     if(plugin) {
       for (auto &parameter : automatedObjectPluginParameters()) {
-        // TODO collect/log stats?
         auto stats = automationElement.apply(*parameter, *plugin);
+        clippedParamInfo.at(parameter->admParameter()).first = stats.clipCount;
       }
 
       for(auto& parameter : trackParameters()) {
@@ -451,4 +453,25 @@ EARPluginSuite::reorderAndFilter(const std::vector<ADMChannel> &channels,
     }
 
     return PluginSuite::reorderAndFilter(modifiedChannels, api);
+}
+
+void admplug::EARPluginSuite::reportClippedParameters()
+{
+    auto haveParamsBeenClipped = [this]() {
+        bool ret = false;
+        for(auto& element : clippedParamInfo) {
+            ret |= element.second.first > 0;
+        }
+        return ret;
+    };
+    
+    if(haveParamsBeenClipped()) {
+        std::string msg{};
+        for(auto& element : clippedParamInfo) {
+          if(element.second.first > 0) {
+            msg.append(std::to_string(element.second.first)+" value(s) of parameter "+element.second.second+"\nhave been clipped to valid range\n");
+          }
+        }
+        broadcaster->warning(msg);
+    }
 }

--- a/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.h
+++ b/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <memory>
+#include <unordered_map>
 #include "pluginsuite.h"
 #include "projectelements.h"
 
@@ -65,5 +66,28 @@ namespace admplug {
         static const int MAX_CHANNEL_COUNT;
 
         static bool registered;
+        
+        void reportClippedParameters();
+        
+        std::unordered_map<AdmParameter, std::pair<int, const std::string>> clippedParamInfo {
+          {AdmParameter::OBJECT_AZIMUTH,                    {0, {"Azimuth"}}},
+          {AdmParameter::OBJECT_ELEVATION,                  {0, {"Elevation"}}},
+          {AdmParameter::OBJECT_DISTANCE,                   {0, {"Distance"}}},
+          {AdmParameter::OBJECT_X,                          {0, {"X"}}},
+          {AdmParameter::OBJECT_Y,                          {0, {"Y"}}},
+          {AdmParameter::OBJECT_Z,                          {0, {"Z"}}},
+          {AdmParameter::OBJECT_HEIGHT,                     {0, {"Height"}}},
+          {AdmParameter::OBJECT_WIDTH,                      {0, {"Width"}}},
+          {AdmParameter::OBJECT_DEPTH,                      {0, {"Depth"}}},
+          {AdmParameter::OBJECT_GAIN,                       {0, {"Gain"}}},
+          {AdmParameter::OBJECT_DIFFUSE,                    {0, {"Diffuse"}}},
+          {AdmParameter::OBJECT_DIVERGENCE,                 {0, {"Divergence"}}},
+          {AdmParameter::OBJECT_DIVERGENCE_AZIMUTH_RANGE,   {0, {"Divergence Azimuth Range"}}},
+          {AdmParameter::SPEAKER_AZIMUTH,                   {0, {"Speaker Azimuth"}}},
+          {AdmParameter::SPEAKER_ELEVATION,                 {0, {"Speaker Elevation"}}},
+          {AdmParameter::SPEAKER_DISTANCE,                  {0, {"Speaker Distance"}}},
+          {AdmParameter::NFC_REF_DIST,                      {0, {"NFC_REF_DIST"}}},
+          {AdmParameter::NONE,                              {0, {"None"}}},
+        };
     };
 }

--- a/reaper-adm-extension/src/reaper_adm/progress/importdialog.cpp
+++ b/reaper-adm-extension/src/reaper_adm/progress/importdialog.cpp
@@ -35,7 +35,8 @@ std::map<ImportStatus, DialogControls> const dialogControlStates{
     {ImportStatus::CREATING_REAPER_ELEMENTS,    {noChange, noChange, "Cancel", false}},
     {ImportStatus::COMPLETE,                    {"Import Complete", "", "OK", true}},
     {ImportStatus::CANCELLED,                   {"Import Cancelled. Tidying up...", "", "Cancel", false}},
-    {ImportStatus::ERROR_OCCURRED,              {"Import Failed", noChange, "OK", true}}
+    {ImportStatus::ERROR_OCCURRED,              {"Import Failed", noChange, "OK", true}},
+    {ImportStatus::WARNING_OCCURRED,            {"Import Warning", noChange, "OK", true}}
 };
 }
 
@@ -158,8 +159,17 @@ INT_PTR ReaperDialogBox::process(HWND window, UINT msg, WPARAM wParam, LPARAM lP
         if(HIWORD(wParam) == BN_CLICKED) {
             // Should really check which button was clicked, but theres only one...
             //if ((HWND)lParam == buttonHwnd)...
-            finish();
+            if(currentState == ImportStatus::WARNING_OCCURRED) {
+              auto progress = parent.lock();
+              if(progress) {
+                  progress->dismissWarning();
+              }
+            }
+            else {
+              finish();
+            }
             return 0;
+
         }
         return DefWindowProc(window, msg, wParam, lParam);
     }
@@ -211,6 +221,15 @@ void ReaperDialogBox::onStateChanged()
               setStatusText(*errorText);
           }
       }
+  }
+  if(currentState == ImportStatus::WARNING_OCCURRED) {
+    auto progress = parent.lock();
+    if(progress) {
+        auto warningText = progress->getWarning();
+        if(warningText) {
+            setStatusText(*warningText);
+        }
+    }
   }
 }
 

--- a/reaper-adm-extension/src/reaper_adm/progress/importlistener.cpp
+++ b/reaper-adm-extension/src/reaper_adm/progress/importlistener.cpp
@@ -59,3 +59,16 @@ void ImportBroadcaster::error(const std::exception &e)
     }
 }
 
+void ImportBroadcaster::warning(const std::string& textToShow)
+{
+    for(auto& listener : listeners) {
+       listener->warning(textToShow);
+    }
+}
+
+void ImportBroadcaster::dismissWarning()
+{
+    for(auto& listener : listeners) {
+       listener->dismissWarning();
+    }
+}

--- a/reaper-adm-extension/src/reaper_adm/progress/importlistener.h
+++ b/reaper-adm-extension/src/reaper_adm/progress/importlistener.h
@@ -4,6 +4,7 @@
 #include <stdexcept>
 #include <memory>
 #include <vector>
+#include <optional>
 
 #include "importstatus.h"
 
@@ -18,6 +19,8 @@ public:
     virtual void totalFrames(uint64_t frames) = 0;
     virtual void framesWritten(uint64_t frames) = 0;
     virtual void error(std::exception const& e) = 0;
+    virtual void warning(const std::string& textToShow) = 0;
+    virtual void dismissWarning() = 0;
 };
 
 class ImportBroadcaster : public ImportListener {
@@ -31,6 +34,8 @@ public:
     virtual void totalFrames(uint64_t frames) override;
     virtual void framesWritten(uint64_t frames) override;
     virtual void error(const std::exception &e) override;
+    virtual void warning(const std::string& textToShow) override;
+    virtual void dismissWarning() override;
 private:
     std::vector<std::shared_ptr<ImportListener>> listeners;
 };

--- a/reaper-adm-extension/src/reaper_adm/progress/importprogress.cpp
+++ b/reaper-adm-extension/src/reaper_adm/progress/importprogress.cpp
@@ -12,7 +12,17 @@ ImportProgress::ImportProgress(REAPER_PLUGIN_HINSTANCE instance,
 
 void ImportProgress::setStatus(ImportStatus newStatus) {
     std::scoped_lock<std::mutex> lock(mutex);
-    state = newStatus;
+    if(state != ImportStatus::WARNING_OCCURRED) {
+      state = newStatus;
+    }
+    else {
+      stateToEnterAfterWarning = newStatus;
+    }
+}
+
+void ImportProgress::dismissWarning() {
+    std::scoped_lock<std::mutex> lock(mutex);
+    state = stateToEnterAfterWarning;
 }
 
 void ImportProgress::elementAdded()
@@ -63,10 +73,24 @@ void ImportProgress::error(const std::exception &e)
     errorText = e.what();
 }
 
+void ImportProgress::warning(const std::string& textToShow)
+{
+    std::scoped_lock<std::mutex> lock(mutex);
+    state = ImportStatus::WARNING_OCCURRED;
+    warningText = textToShow;
+}
+
+
 std::optional<std::string> ImportProgress::getError() {
 
     std::scoped_lock<std::mutex> lock(mutex);
     return errorText;
+}
+
+std::optional<std::string> ImportProgress::getWarning() {
+
+    std::scoped_lock<std::mutex> lock(mutex);
+    return warningText;
 }
 
 

--- a/reaper-adm-extension/src/reaper_adm/progress/importprogress.h
+++ b/reaper-adm-extension/src/reaper_adm/progress/importprogress.h
@@ -26,16 +26,21 @@ public:
     virtual void totalFrames(uint64_t frames) override;
     virtual void framesWritten(uint64_t frames) override;
     void error(const std::exception &e) override;
+    void warning(const std::string& textToShow) override;
+    void dismissWarning() override;
     ImportStatus status() const override;
     ElementProgress getProgress();
     void dialogClosed();
     void setDialog(ReaperDialogBox* box);
     std::pair<uint64_t, uint64_t> sampleProgress();
     std::optional<std::string> getError();
+    std::optional<std::string> getWarning();
+    ImportStatus getStateToEnterAfterWarning() { return stateToEnterAfterWarning; }
 private:
     uint64_t frameCount{0};
     uint64_t currentFrames{0};
     ImportStatus state{ImportStatus::INIT};
+    ImportStatus stateToEnterAfterWarning{ImportStatus::INIT};
     mutable std::mutex mutex;
     ElementProgress progress{};
     void setHeaderText(const std::string &text);
@@ -46,6 +51,7 @@ private:
     HWND main{nullptr};
     ReaperDialogBox* box {nullptr};
     std::optional<std::string> errorText;
+    std::optional<std::string> warningText;
 };
 
 }

--- a/reaper-adm-extension/src/reaper_adm/progress/importstatus.h
+++ b/reaper-adm-extension/src/reaper_adm/progress/importstatus.h
@@ -11,6 +11,7 @@ enum class ImportStatus {
     CREATING_REAPER_ELEMENTS,
     COMPLETE,
     CANCELLED,
-    ERROR_OCCURRED
+    ERROR_OCCURRED,
+    WARNING_OCCURRED
 };
 }

--- a/reaper-adm-extension/test/reaper_adm/mocks/importlistener.h
+++ b/reaper-adm-extension/test/reaper_adm/mocks/importlistener.h
@@ -10,5 +10,7 @@ public:
     MOCK_METHOD1(totalFrames, void(uint64_t frames));
     MOCK_METHOD1(framesWritten, void(uint64_t frames));
     MOCK_METHOD1(error, void(const std::exception& e));
+    MOCK_METHOD1(warning, void(const std::string& w));
+    MOCK_METHOD0(dismissWarning, void());
 };
 


### PR DESCRIPTION
…as been generated, ImportProgress will store the next state from consecutive setStatus() calls and continue there after dismissal of the warning)

- ParameterValue: make clipped member public, implement copy constructor
- AutomationPoint: take a ParameterValue instead of double as constructor arg
- ParameterValueMapping: construct ParameterValue with correct clipped argument, prevent clipped state from being overwritten in consecutive mappings (default constructor...)
- EARPluginSuite: collect stats and report clipped parameters
- Problem: clipped state of ParameterValue is still being overwritten by default construction in combination with AutomationPoint