### PR TITLE
Integrate previous changes and connect everything for reporting of parameter clipped state

### DIFF
--- a/reaper-adm-extension/src/reaper_adm/automationpoint.h
+++ b/reaper-adm-extension/src/reaper_adm/automationpoint.h
@@ -7,6 +7,7 @@ class ParameterValue {
 public:
   explicit ParameterValue(double value) : value{value}, clipped{false} {}
   ParameterValue(double value, bool clipped) : value{value}, clipped{clipped} {}
+  ParameterValue(const ParameterValue& obj) : value{obj.value}, clipped{obj.clipped} {}
   double get() const { return value; }
   bool operator< (double other) const {
     return get() < other;
@@ -33,12 +34,11 @@ public:
 //    return get() - other;
 //  }
 //  operator double() const { return get(); }
-  bool wasClipped() const { return clipped; }
-  void setClipped() { clipped = true; }
+  
+  bool clipped;
 
 private:
   double value;
-  bool clipped;
 };
 
 

--- a/reaper-adm-extension/src/reaper_adm/objectautomationelement.cpp
+++ b/reaper-adm-extension/src/reaper_adm/objectautomationelement.cpp
@@ -1,4 +1,4 @@
-﻿#include <optional>
+#include <optional>
 #include <tuple>
 #include "objectautomationelement.h"
 #include "automationenvelope.h"
@@ -177,7 +177,7 @@ namespace {
   ParameterStats getStatsFor(std::vector<AutomationPoint> const& points) {
     ParameterStats stats;
     for (auto const &point : points) {
-      if (point.value().wasClipped()) {
+      if (point.value().clipped) {
         ++stats.clipCount;
       }
     }

--- a/reaper-adm-extension/src/reaper_adm/parametervaluemapping.cpp
+++ b/reaper-adm-extension/src/reaper_adm/parametervaluemapping.cpp
@@ -41,12 +41,8 @@ CompositeMapping::CompositeMapping(std::vector<std::shared_ptr<const ParameterVa
 
 ParameterValue admplug::CompositeMapping::forwardMap(ParameterValue val) const
 {
-    bool clipped = val.clipped; // clipped info will get lost in consecutive mappings
-
     for(int i = 0; i < mappings.size(); i++) {
         val = mappings[i]->forwardMap(val);
-        clipped = val.clipped || clipped;
-        val.clipped = clipped;
     }
     return val;
 
@@ -54,12 +50,8 @@ ParameterValue admplug::CompositeMapping::forwardMap(ParameterValue val) const
 
 ParameterValue admplug::CompositeMapping::reverseMap(ParameterValue val) const
 {
-    bool clipped = val.clipped; // clipped info will get lost in consecutive mappings
-
     for(int i = (mappings.size() - 1); i >= 0; i--) {
         val = mappings[i]->reverseMap(val);
-        clipped = val.clipped || clipped;
-        val.clipped = clipped;
     }
     return val;
 

--- a/reaper-adm-extension/src/reaper_adm/parametervaluemapping.cpp
+++ b/reaper-adm-extension/src/reaper_adm/parametervaluemapping.cpp
@@ -41,18 +41,28 @@ CompositeMapping::CompositeMapping(std::vector<std::shared_ptr<const ParameterVa
 
 ParameterValue admplug::CompositeMapping::forwardMap(ParameterValue val) const
 {
+    bool clipped = val.clipped; // clipped info will get lost in consecutive mappings
+
     for(int i = 0; i < mappings.size(); i++) {
         val = mappings[i]->forwardMap(val);
+        clipped = val.clipped || clipped;
+        val.clipped = clipped;
     }
     return val;
+
 }
 
 ParameterValue admplug::CompositeMapping::reverseMap(ParameterValue val) const
 {
+    bool clipped = val.clipped; // clipped info will get lost in consecutive mappings
+
     for(int i = (mappings.size() - 1); i >= 0; i--) {
         val = mappings[i]->reverseMap(val);
+        clipped = val.clipped || clipped;
+        val.clipped = clipped;
     }
     return val;
+
 }
 
 void CompositeMapping::addMapping(std::shared_ptr<ParameterValueMapping> mapping)
@@ -75,7 +85,7 @@ std::shared_ptr<ParameterValueMapping const> ParameterRange::modulus() const {
             return val;
         }
         auto range = maximum - minimum;
-        return ParameterValue{fmod(val.get() - minimum, range) + minimum, val.wasClipped()};
+        return ParameterValue{fmod(val.get() - minimum, range) + minimum, val.clipped};
     },
         [](ParameterValue val) {
         // Can't properly undo without original data
@@ -91,7 +101,7 @@ std::shared_ptr<ParameterValueMapping const> ParameterRange::clipper() const {
         [minimum, maximum](ParameterValue val) {
         auto clipped = std::max(val.get(), minimum);
         clipped = std::min(clipped, maximum);
-        return ParameterValue{clipped, true};
+        return ParameterValue{clipped, (val.get() < minimum) || (val.get() > maximum)};
     },
         [](ParameterValue val) {
         // Can't properly undo without original data
@@ -106,11 +116,11 @@ std::shared_ptr<ParameterValueMapping const> ParameterRange::normaliser() const 
     return std::make_shared<FunctionalMapping>(
         [minimum, maximum](ParameterValue val) {
         auto range = maximum - minimum;
-        return ParameterValue((val.get() - minimum) / range, val.wasClipped());
+        return ParameterValue((val.get() - minimum) / range, val.clipped);
     },
         [minimum, maximum](ParameterValue val) {
         auto range = maximum - minimum;
-        return ParameterValue((val.get() * range) + minimum, val.wasClipped());
+        return ParameterValue((val.get() * range) + minimum, val.clipped);
     }
     );
 }
@@ -118,12 +128,12 @@ std::shared_ptr<ParameterValueMapping const> ParameterRange::normaliser() const 
 
 ParameterValue admplug::Inversion::forwardMap(ParameterValue val) const
 {
-    return ParameterValue(-val.get(), val.wasClipped());
+    return ParameterValue(-val.get(), val.clipped);
 }
 
 ParameterValue admplug::Inversion::reverseMap(ParameterValue val) const
 {
-    return ParameterValue(-val.get(), val.wasClipped());
+    return ParameterValue(-val.get(), val.clipped);
 }
 
 
@@ -176,10 +186,10 @@ ParameterValue LinearToDb::forwardMap(ParameterValue val) const
     } else {
       db = 20.0 * log10(val.get());
     }
-    return ParameterValue(db, val.wasClipped());
+    return ParameterValue(db, val.clipped);
 }
 
 ParameterValue LinearToDb::reverseMap(ParameterValue val) const
 {
-    return ParameterValue(pow(10, val.get()/20), val.wasClipped());
+    return ParameterValue(pow(10, val.get()/20), val.clipped);
 }

--- a/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.h
+++ b/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.h
@@ -2,6 +2,8 @@
 
 #include <string>
 #include <memory>
+#include <unordered_map>
+
 #include "pluginsuite.h"
 #include "projectelements.h"
 
@@ -65,5 +67,29 @@ namespace admplug {
         static const int MAX_CHANNEL_COUNT;
 
         static bool registered;
+        
+        void reportClippedParameters();
+        
+        std::unordered_map<AdmParameter, std::pair<int, const std::string>> clippedParamInfo {
+          {AdmParameter::OBJECT_AZIMUTH,                    {0, {"Azimuth"}}},
+          {AdmParameter::OBJECT_ELEVATION,                  {0, {"Elevation"}}},
+          {AdmParameter::OBJECT_DISTANCE,                   {0, {"Distance"}}},
+          {AdmParameter::OBJECT_X,                          {0, {"X"}}},
+          {AdmParameter::OBJECT_Y,                          {0, {"Y"}}},
+          {AdmParameter::OBJECT_Z,                          {0, {"Z"}}},
+          {AdmParameter::OBJECT_HEIGHT,                     {0, {"Height"}}},
+          {AdmParameter::OBJECT_WIDTH,                      {0, {"Width"}}},
+          {AdmParameter::OBJECT_DEPTH,                      {0, {"Depth"}}},
+          {AdmParameter::OBJECT_GAIN,                       {0, {"Gain"}}},
+          {AdmParameter::OBJECT_DIFFUSE,                    {0, {"Diffuse"}}},
+          {AdmParameter::OBJECT_DIVERGENCE,                 {0, {"Divergence"}}},
+          {AdmParameter::OBJECT_DIVERGENCE_AZIMUTH_RANGE,   {0, {"Divergence Azimuth Range"}}},
+          {AdmParameter::SPEAKER_AZIMUTH,                   {0, {"Speaker Azimuth"}}},
+          {AdmParameter::SPEAKER_ELEVATION,                 {0, {"Speaker Elevation"}}},
+          {AdmParameter::SPEAKER_DISTANCE,                  {0, {"Speaker Distance"}}},
+          {AdmParameter::NFC_REF_DIST,                      {0, {"NFC_REF_DIST"}}},
+          {AdmParameter::NONE,                              {0, {"None"}}},
+        };
+
     };
 }

--- a/reaper-adm-extension/src/reaper_adm/progress/importdialog.cpp
+++ b/reaper-adm-extension/src/reaper_adm/progress/importdialog.cpp
@@ -35,7 +35,8 @@ std::map<ImportStatus, DialogControls> const dialogControlStates{
     {ImportStatus::CREATING_REAPER_ELEMENTS,    {noChange, noChange, "Cancel", false}},
     {ImportStatus::COMPLETE,                    {"Import Complete", "", "OK", true}},
     {ImportStatus::CANCELLED,                   {"Import Cancelled. Tidying up...", "", "Cancel", false}},
-    {ImportStatus::ERROR_OCCURRED,              {"Import Failed", noChange, "OK", true}}
+    {ImportStatus::ERROR_OCCURRED,              {"Import Failed", noChange, "OK", true}},
+    {ImportStatus::WARNING_OCCURRED,            {"Import Warning", noChange, "OK", true}}
 };
 }
 
@@ -158,7 +159,15 @@ INT_PTR ReaperDialogBox::process(HWND window, UINT msg, WPARAM wParam, LPARAM lP
         if(HIWORD(wParam) == BN_CLICKED) {
             // Should really check which button was clicked, but theres only one...
             //if ((HWND)lParam == buttonHwnd)...
-            finish();
+            if(currentState == ImportStatus::WARNING_OCCURRED) {
+              auto progress = parent.lock();
+              if(progress) {
+                  progress->dismissWarning();
+              }
+            }
+            else {
+              finish();
+            }
             return 0;
         }
         return DefWindowProc(window, msg, wParam, lParam);
@@ -211,6 +220,15 @@ void ReaperDialogBox::onStateChanged()
               setStatusText(*errorText);
           }
       }
+  }
+  if(currentState == ImportStatus::WARNING_OCCURRED) {
+    auto progress = parent.lock();
+    if(progress) {
+        auto warningText = progress->getWarning();
+        if(warningText) {
+            setStatusText(*warningText);
+        }
+    }
   }
 }
 

--- a/reaper-adm-extension/src/reaper_adm/progress/importlistener.cpp
+++ b/reaper-adm-extension/src/reaper_adm/progress/importlistener.cpp
@@ -59,3 +59,16 @@ void ImportBroadcaster::error(const std::exception &e)
     }
 }
 
+void ImportBroadcaster::warning(const std::string& textToShow)
+{
+    for(auto& listener : listeners) {
+       listener->warning(textToShow);
+    }
+}
+
+void ImportBroadcaster::dismissWarning()
+{
+    for(auto& listener : listeners) {
+       listener->dismissWarning();
+    }
+}

--- a/reaper-adm-extension/src/reaper_adm/progress/importlistener.h
+++ b/reaper-adm-extension/src/reaper_adm/progress/importlistener.h
@@ -4,7 +4,7 @@
 #include <stdexcept>
 #include <memory>
 #include <vector>
-
+#include <optional>
 #include "importstatus.h"
 
 namespace admplug {
@@ -18,6 +18,8 @@ public:
     virtual void totalFrames(uint64_t frames) = 0;
     virtual void framesWritten(uint64_t frames) = 0;
     virtual void error(std::exception const& e) = 0;
+    virtual void warning(const std::string& textToShow) = 0;
+    virtual void dismissWarning() = 0;
 };
 
 class ImportBroadcaster : public ImportListener {
@@ -31,6 +33,8 @@ public:
     virtual void totalFrames(uint64_t frames) override;
     virtual void framesWritten(uint64_t frames) override;
     virtual void error(const std::exception &e) override;
+    virtual void warning(const std::string& textToShow) override;
+    virtual void dismissWarning() override;
 private:
     std::vector<std::shared_ptr<ImportListener>> listeners;
 };

--- a/reaper-adm-extension/src/reaper_adm/progress/importprogress.cpp
+++ b/reaper-adm-extension/src/reaper_adm/progress/importprogress.cpp
@@ -10,9 +10,21 @@ ImportProgress::ImportProgress(REAPER_PLUGIN_HINSTANCE instance,
 
 }
 
-void ImportProgress::setStatus(ImportStatus newStatus) {
+void ImportProgress::setStatus(ImportStatus newStatus)
+{
     std::scoped_lock<std::mutex> lock(mutex);
-    state = newStatus;
+    if(state != ImportStatus::WARNING_OCCURRED) {
+      state = newStatus;
+    }
+    else {
+      stateToEnterAfterWarning = newStatus;
+    }
+}
+
+void ImportProgress::dismissWarning()
+{
+    std::scoped_lock<std::mutex> lock(mutex);
+    state = stateToEnterAfterWarning;
 }
 
 void ImportProgress::elementAdded()
@@ -63,12 +75,24 @@ void ImportProgress::error(const std::exception &e)
     errorText = e.what();
 }
 
-std::optional<std::string> ImportProgress::getError() {
+void ImportProgress::warning(const std::string& textToShow)
+{
+    std::scoped_lock<std::mutex> lock(mutex);
+    state = ImportStatus::WARNING_OCCURRED;
+    warningText = textToShow;
+}
 
+std::optional<std::string> ImportProgress::getError()
+{
     std::scoped_lock<std::mutex> lock(mutex);
     return errorText;
 }
 
+std::optional<std::string> ImportProgress::getWarning()
+{
+    std::scoped_lock<std::mutex> lock(mutex);
+    return warningText;
+}
 
 void ImportProgress::dialogClosed()
 {

--- a/reaper-adm-extension/src/reaper_adm/progress/importprogress.h
+++ b/reaper-adm-extension/src/reaper_adm/progress/importprogress.h
@@ -26,16 +26,21 @@ public:
     virtual void totalFrames(uint64_t frames) override;
     virtual void framesWritten(uint64_t frames) override;
     void error(const std::exception &e) override;
+    void warning(const std::string& textToShow) override;
+    void dismissWarning() override;
     ImportStatus status() const override;
     ElementProgress getProgress();
     void dialogClosed();
     void setDialog(ReaperDialogBox* box);
     std::pair<uint64_t, uint64_t> sampleProgress();
     std::optional<std::string> getError();
+    std::optional<std::string> getWarning();
+    ImportStatus getStateToEnterAfterWarning() { return stateToEnterAfterWarning; }
 private:
     uint64_t frameCount{0};
     uint64_t currentFrames{0};
     ImportStatus state{ImportStatus::INIT};
+    ImportStatus stateToEnterAfterWarning{ImportStatus::INIT};
     mutable std::mutex mutex;
     ElementProgress progress{};
     void setHeaderText(const std::string &text);
@@ -46,6 +51,7 @@ private:
     HWND main{nullptr};
     ReaperDialogBox* box {nullptr};
     std::optional<std::string> errorText;
+    std::optional<std::string> warningText;
 };
 
 }

--- a/reaper-adm-extension/src/reaper_adm/progress/importstatus.h
+++ b/reaper-adm-extension/src/reaper_adm/progress/importstatus.h
@@ -11,6 +11,7 @@ enum class ImportStatus {
     CREATING_REAPER_ELEMENTS,
     COMPLETE,
     CANCELLED,
-    ERROR_OCCURRED
+    ERROR_OCCURRED,
+    WARNING_OCCURRED
 };
 }

--- a/reaper-adm-extension/test/reaper_adm/earsuitetests.cpp
+++ b/reaper-adm-extension/test/reaper_adm/earsuitetests.cpp
@@ -1,4 +1,4 @@
-﻿#include <catch2/catch.hpp>
+#include <catch2/catch.hpp>
 #include <gmock/gmock.h>
 #include "mocks/reaperapi.h"
 #include "mocks/projectelements.h"
@@ -13,7 +13,7 @@
 #include <adm/common_definitions.hpp>
 namespace admplug {
 bool operator==(ParameterValue const &lhs, ParameterValue const &rhs) {
-  return lhs.get() == rhs.get() && lhs.wasClipped() == rhs.wasClipped();
+  return lhs.get() == rhs.get() && lhs.clipped == rhs.clipped;
 }
 }
 

--- a/reaper-adm-extension/test/reaper_adm/mocks/importlistener.h
+++ b/reaper-adm-extension/test/reaper_adm/mocks/importlistener.h
@@ -10,5 +10,7 @@ public:
     MOCK_METHOD1(totalFrames, void(uint64_t frames));
     MOCK_METHOD1(framesWritten, void(uint64_t frames));
     MOCK_METHOD1(error, void(const std::exception& e));
+    MOCK_METHOD1(warning, void(const std::string& w));
+    MOCK_METHOD0(dismissWarning, void());
 };
 


### PR DESCRIPTION
- Import: add option to show warning in dialog box (once a warning ha…s been generated, ImportProgress will store the next state from consecutive setStatus() calls and continue there after dismissal of the warning)

- ParameterValue: make clipped member public, implement copy constructor
- ParameterValueMapping: construct ParameterValue with correct clipped argument, prevent clipped state from being overwritten in consecutive mappings
- EARPluginSuite: collect stats, take into account consecutive passes with already clipped values, report clipped parameters